### PR TITLE
Added Footer Partial Support

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,6 +19,7 @@
       {{ if $paginator.HasNext }}<a href="{{ $paginator.Next.URL }}" class="pagination-older">Older Posts &gt;</a>{{ end }}
     </nav>
     {{ end -}}
+    {{ partial "footer.html" . }}
     {{ partial "scripts.html" . }}
   </body>
 </html>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,6 +28,7 @@
       {{ end }}
       {{ partial "home-card.html" . }}
     </nav>
+    {{ partial "footer.html" . }}
     {{ partial "scripts.html" . }}
   </body>
 </html>


### PR DESCRIPTION
This commit includes the footer.html partial file in the template so that it can be overridden to include content at the base of each page such as copyright notice, bottom menu, etc.