### PR TITLE
Content from _index.md is now included in list pages.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -8,6 +8,7 @@
         <p class="list-header-subtext">{{ .Description }}</p>
         <h1 class="list-header-title">{{ .Title }}</h1>
       </header>
+      {{ .Content }}
       {{ $paginator := .Paginate (where .Pages "Params.displayinlist" "!=" false) -}}
       {{- range $paginator.Pages -}}
         {{ .Render "li" }}


### PR DESCRIPTION
Small change to include content from _index.md files in list pages. If no _index.md is provided, it should not have any effect.