### PR TITLE
Fix home-card href bug if baseURL is not set

### DIFF
--- a/layouts/partials/home-card.html
+++ b/layouts/partials/home-card.html
@@ -1,4 +1,5 @@
 <a ontouchstart="cardPressed.call(this)" ontouchend="cardReleased.call(this)" ontouchmove="cardReleased.call(this)" 
-  href="{{ .Site.BaseURL }}" class="card home-card" style="background-image: url({{if isset .Site.Params "homeimg"}} {{ (resources.Get .Site.Params.homeimg).Permalink | safeCSS }} {{ else }} {{ (resources.Get "img/grey-cloud.jpg").Permalink | safeCSS }} {{ end }})" rel="bookmark" >
+  href="{{ if isset .Site "BaseURL" }} {{ .Site.BaseURL }} {{ else }} {{ "/" }} {{ end }}"
+  class="card home-card" style="background-image: url({{if isset .Site.Params "homeimg"}} {{ (resources.Get .Site.Params.homeimg).Permalink | safeCSS }} {{ else }} {{ (resources.Get "img/grey-cloud.jpg").Permalink | safeCSS }} {{ end }})" rel="bookmark" >
   Home
 </a>


### PR DESCRIPTION
I found that if baseURL is not set, the home-card will redirect you to the current page.