### PR TITLE
Add aria-label to hamburger menu

### DIFF
--- a/layouts/partials/nav-bar.html
+++ b/layouts/partials/nav-bar.html
@@ -9,6 +9,7 @@
   <div class="hamburger-menu">
     <input class="hamburger-menu-button" type="checkbox"
       onclick="hamburgerMenuPressed.call(this)"
+      aria-label="Hamburger Menu Button"
     >
     <div class="hamburger-menu-icon">
       <span></span>


### PR DESCRIPTION
Hey buddy. I love your theme. I use it for my blog at [trollmoj.com](https://trollmoj.com)

I noticed that Lighthouse bumped my Accessibility scoring from 73 to 93 by adding this aria-label. It probably has pretty little practical impact, but anything to avoid penalties in from the search engines. :) 

You may want to use a different label, I just pulled one out of my... thin air.